### PR TITLE
feature(sftp): Add support for old algorithms

### DIFF
--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -344,7 +344,8 @@ func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
 
 	if opt.UseInsecureCipher {
 		sshConfig.Config.SetDefaults()
-		sshConfig.Config.Ciphers = append(sshConfig.Config.Ciphers, "aes128-cbc")
+		sshConfig.Config.Ciphers = append(sshConfig.Config.Ciphers, "aes128-cbc", "aes192-cbc", "aes256-cbc")
+		sshConfig.Config.KeyExchanges = append(sshConfig.Config.KeyExchanges, "diffie-hellman-group-exchange-sha1", "diffie-hellman-group-exchange-sha256")
 	}
 
 	keyFile := env.ShellExpand(opt.KeyFile)

--- a/vendor/golang.org/x/crypto/ssh/cipher.go
+++ b/vendor/golang.org/x/crypto/ssh/cipher.go
@@ -125,6 +125,8 @@ var cipherModes = map[string]*cipherMode{
 	// You should expect that an active attacker can recover plaintext if
 	// you do.
 	aes128cbcID: {16, aes.BlockSize, newAESCBCCipher},
+	aes192cbcID: {24, aes.BlockSize, newAESCBCCipher},
+	aes256cbcID: {32, aes.BlockSize, newAESCBCCipher},
 
 	// 3des-cbc is insecure and is not included in the default
 	// config.

--- a/vendor/golang.org/x/crypto/ssh/transport.go
+++ b/vendor/golang.org/x/crypto/ssh/transport.go
@@ -19,6 +19,8 @@ const debugTransport = false
 const (
 	gcmCipherID    = "aes128-gcm@openssh.com"
 	aes128cbcID    = "aes128-cbc"
+	aes192cbcID    = "aes192-cbc"
+	aes256cbcID    = "aes256-cbc"
 	tripledescbcID = "3des-cbc"
 )
 


### PR DESCRIPTION
* Whitelisted key exchange via diffie-hellman-group-exchange-sha256
  and diffie-hellman-group-exchange-sha1
* Added support for cipher aes256-cbc and aes192-cbc
